### PR TITLE
minimize diff in indexed-search

### DIFF
--- a/justfile
+++ b/justfile
@@ -15,10 +15,6 @@ freeze: freeze-dhall
 
 check: check-dhall
 
-check-pkg: check-package
-
-check-package: check-dhall-package
-
 prettier:
     yarn run prettier
 
@@ -30,11 +26,6 @@ build-docker-compose:
 
 check-dhall:
     ./scripts/dhall-check.sh
-
-k8s-package-file := "./src/k8s/package.dhall"
-
-check-dhall-package:
-    ./scripts/dhall-check.sh '{{k8s-package-file}}'
 
 format-dhall:
     ./scripts/dhall-format.sh
@@ -73,7 +64,7 @@ deploy-sourcegraph-file := "./deploy-sourcegraph.dhall"
 pipeline-file := "./src/k8s/pipeline.dhall"
 
 diff-ds:
-    dhall diff '{{deploy-sourcegraph-file}}' '{{pipeline-file}}'
+    dhall diff '({{deploy-sourcegraph-file}}).indexed-search' '({{pipeline-file}}).indexed-search'
 
 rewrite: rewrite-ds
 

--- a/src/k8s/components/gitserver/configuration/internal/statefulset.dhall
+++ b/src/k8s/components/gitserver/configuration/internal/statefulset.dhall
@@ -27,7 +27,6 @@ let Container/gitserver =
       , rpc/port : Natural
       , securityContext : Optional Kubernetes/SecurityContext.Type
       , containerResources : Optional Kubernetes/ResourceRequirements.Type
-      , reposVolumeSize : Text
       , envVars : Optional (List Kubernetes/EnvVar.Type)
       , volumeMounts : Optional (List Kubernetes/VolumeMount.Type)
       }
@@ -46,6 +45,7 @@ let config =
       , podSecurityContext : Optional Kubernetes/PodSecurityContext.Type
       , Containers : ContainerConfiguration
       , storageClassName : Optional Text
+      , reposVolumeSize : Text
       , sideCars : List Kubernetes/Container.Type
       }
 

--- a/src/k8s/components/gitserver/configuration/toInternal.dhall
+++ b/src/k8s/components/gitserver/configuration/toInternal.dhall
@@ -211,7 +211,6 @@ let StatefulSet/toInternal
         let gitserverContainer =
               { image = gitserverImage
               , rpc/port = simple/gitserver.ports.rpc
-              , reposVolumeSize = cg.gitserver.StatefulSet.reposVolumeSize
               , containerResources = gitserverResources
               , healthcheck = gitServerHealthCheck
               , securityContext
@@ -226,6 +225,7 @@ let StatefulSet/toInternal
               { gitserver = gitserverContainer
               , jaeger = Container/Jaeger/toInternal cg
               }
+            , reposVolumeSize = cg.gitserver.StatefulSet.reposVolumeSize
             , podSecurityContext
             , sideCars = cg.gitserver.StatefulSet.additionalSideCars
             }

--- a/src/k8s/components/gitserver/generate/statefulset.dhall
+++ b/src/k8s/components/gitserver/generate/statefulset.dhall
@@ -137,9 +137,7 @@ let generate
                       , storageClassName = c.storageClassName
                       , resources = Some Kubernetes/ResourceRequirements::{
                         , requests = Some
-                          [ { mapKey = "storage"
-                            , mapValue = c.Containers.gitserver.reposVolumeSize
-                            }
+                          [ { mapKey = "storage", mapValue = c.reposVolumeSize }
                           ]
                         }
                       }

--- a/src/k8s/components/indexed-search/configuration/internal/statefulset.dhall
+++ b/src/k8s/components/indexed-search/configuration/internal/statefulset.dhall
@@ -11,6 +11,8 @@ let StatefulSetConfiguration =
       , replicas : Natural
       , Containers : ContainerConfiguration
       , sideCars : List Kubernetes/Container.Type
+      , dataVolumeSize : Text
+      , storageClassName : Optional Text
       }
 
 in  StatefulSetConfiguration

--- a/src/k8s/components/indexed-search/configuration/toInternal.dhall
+++ b/src/k8s/components/indexed-search/configuration/toInternal.dhall
@@ -254,6 +254,8 @@ let StatefulSet/toInternal
     = λ(cg : Configuration/global.Type) →
         let namespace = cg.Global.namespace
 
+        let storageClassName = cg.Global.storageClassname
+
         let opts = cg.indexed-search.StatefulSet
 
         let replicas = opts.replicas
@@ -265,6 +267,8 @@ let StatefulSet/toInternal
               , zoekt-webserver = Container/Zoekt-Webserver/toInternal cg
               }
             , sideCars = opts.additionalSideCars
+            , storageClassName
+            , dataVolumeSize = opts.dataVolumeSize
             }
 
 let Test/StatefulSet/Namespace/none =

--- a/src/k8s/components/indexed-search/configuration/user.dhall
+++ b/src/k8s/components/indexed-search/configuration/user.dhall
@@ -91,11 +91,13 @@ let StatefulSet =
           { replicas : Natural
           , Containers : Containers.Type
           , additionalSideCars : List Kubernetes/Container.Type
+          , dataVolumeSize : Text
           }
       , default =
         { replicas = 1
         , Containers = Containers.default
         , additionalSideCars = [] : List Kubernetes/Container.Type
+        , dataVolumeSize = "200Gi"
         }
       }
 

--- a/src/k8s/components/indexed-search/documentation.md
+++ b/src/k8s/components/indexed-search/documentation.md
@@ -14,6 +14,7 @@
       - [resources](#resources-1)
       - [additional volume mounts](#additional-volume-mounts-1)
   - [Additional SideCar Containers](#additional-sidecar-containers)
+  - [Data volume size](#data-volume-size)
 
 # StatefulSet
 
@@ -218,4 +219,16 @@ Sourcegraph.Kubernetes.Container::{
           , image = Some "index.docker.io/your/image:tag@sha256:123456"
           , name = "sidecar"
 }
+```
+
+## Data volume size
+
+```dhall
+with indexed-search.StatefulSet.dataVolumeSize = <Text>
+```
+
+**Default value**:
+
+```dhall
+"200Gi"
 ```

--- a/src/k8s/components/indexed-search/generate/container/zoekt-webserver.dhall
+++ b/src/k8s/components/indexed-search/generate/container/zoekt-webserver.dhall
@@ -34,11 +34,11 @@ let Container/zoekt-webserver/generate
 
         let k8sProbe = util.HealthCheck/tok8s simple/zoekt-webserver.HealthCheck
 
-        let probe = k8sProbe with failureThreshold = None Natural
-
         let readinessProbe
             : Kubernetes/Probe.Type
-            = probe
+            = k8sProbe
+              with periodSeconds = Some 5
+              with failureThreshold = Some 3
               with initialDelaySeconds = None Natural
 
         let httpPort =

--- a/src/k8s/components/indexed-search/generate/service/indexed-search-indexer.dhall
+++ b/src/k8s/components/indexed-search/generate/service/indexed-search-indexer.dhall
@@ -49,9 +49,10 @@ let Service/generate
                 , name = Some "indexed-search-indexer"
                 }
               , spec = Some Kubernetes/ServiceSpec::{
+                , clusterIP = Some "None"
                 , ports = Some
                   [ Kubernetes/ServicePort::{
-                    , name = Some "port"
+
                     , port = 6072
                     , targetPort = Some
                         (< Int : Natural | String : Text >.Int 6072)

--- a/src/k8s/components/indexed-search/generate/service/indexed-search-indexer.dhall
+++ b/src/k8s/components/indexed-search/generate/service/indexed-search-indexer.dhall
@@ -52,7 +52,6 @@ let Service/generate
                 , clusterIP = Some "None"
                 , ports = Some
                   [ Kubernetes/ServicePort::{
-
                     , port = 6072
                     , targetPort = Some
                         (< Int : Natural | String : Text >.Int 6072)

--- a/src/k8s/components/indexed-search/generate/service/indexed-search.dhall
+++ b/src/k8s/components/indexed-search/generate/service/indexed-search.dhall
@@ -49,8 +49,9 @@ let Service/generate
                 , name = Some "indexed-search"
                 }
               , spec = Some Kubernetes/ServiceSpec::{
+                , clusterIP = Some "None"
                 , ports = Some
-                  [ Kubernetes/ServicePort::{ name = Some "port", port = 6070 }
+                  [ Kubernetes/ServicePort::{ port = 6070 }
                   ]
                 , selector = Some
                   [ { mapKey = "app", mapValue = "indexed-search" } ]

--- a/src/k8s/components/indexed-search/generate/service/indexed-search.dhall
+++ b/src/k8s/components/indexed-search/generate/service/indexed-search.dhall
@@ -50,9 +50,7 @@ let Service/generate
                 }
               , spec = Some Kubernetes/ServiceSpec::{
                 , clusterIP = Some "None"
-                , ports = Some
-                  [ Kubernetes/ServicePort::{ port = 6070 }
-                  ]
+                , ports = Some [ Kubernetes/ServicePort::{ port = 6070 } ]
                 , selector = Some
                   [ { mapKey = "app", mapValue = "indexed-search" } ]
                 , type = Some "ClusterIP"

--- a/src/k8s/components/indexed-search/generate/statefulset/fixtures.dhall
+++ b/src/k8s/components/indexed-search/generate/statefulset/fixtures.dhall
@@ -3,8 +3,22 @@ let Kubernetes/Container =
 
 let Fixtures/containers = ../container/fixtures.dhall
 
+let Kubernetes/PersistentVolumeClaimSpec =
+      ../../../../../deps/k8s/schemas/io.k8s.api.core.v1.PersistentVolumeClaimSpec.dhall
+
+let Kubernetes/ResourceRequirements =
+      ../../../../../deps/k8s/schemas/io.k8s.api.core.v1.ResourceRequirements.dhall
+
+let Kubernetes/ObjectMeta =
+      ../../../../../deps/k8s/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.dhall
+
+let Kubernetes/PersistentVolumeClaim =
+      ../../../../../deps/k8s/schemas/io.k8s.api.core.v1.PersistentVolumeClaim.dhall
+
 let Configuration/Internal/StatefulSet =
       ../../configuration/internal/statefulset.dhall
+
+let DATA_VOLUME_SIZE = "DATA_VOLUME_SIZE"
 
 let TestConfig
     : Configuration/Internal/StatefulSet
@@ -16,6 +30,33 @@ let TestConfig
       , namespace = None Text
       , replicas = 1
       , sideCars = [] : List Kubernetes/Container.Type
+      , storageClassName = None Text
+      , dataVolumeSize = DATA_VOLUME_SIZE
       }
 
-in  { indexed-search.Config = TestConfig }
+let TestStorageClassName = "FAKE_NAME_HERE"
+
+let TestSize = "111111111Mi"
+
+let TestVolume =
+      Kubernetes/PersistentVolumeClaim::{
+      , metadata = Kubernetes/ObjectMeta::{
+        , labels = Some (toMap { deploy = "sourcegraph" })
+        , name = Some "data"
+        }
+      , spec = Some Kubernetes/PersistentVolumeClaimSpec::{
+        , accessModes = Some [ "ReadWriteOnce" ]
+        , resources = Some Kubernetes/ResourceRequirements::{
+          , requests = Some [ { mapKey = "storage", mapValue = TestSize } ]
+          }
+        , storageClassName = Some TestStorageClassName
+        }
+      }
+
+in  { indexed-search.Config = TestConfig
+    , Volume =
+      { StorageClassName = TestStorageClassName
+      , Size = TestSize
+      , Expected = TestVolume
+      }
+    }


### PR DESCRIPTION
I spent some time re-working some of indexed-search to minimize diffs (mostly with the utility functions [1](https://github.com/sourcegraph/deploy-sourcegraph-core/blob/main/src/k8s/util/functions/join-optional-list.dhall) and [2](https://github.com/sourcegraph/deploy-sourcegraph-core/blob/main/src/k8s/util/functions/list-to-optional.dhall) in my last PR. 

A question. It seems like the statefulset for this one doesn't have any volume claim templates. Was that intentional @uwedeportivo ? 