### PR TITLE
Update minio envvars to new convention

### DIFF
--- a/src/k8s/components/minio/configuration/environment/environment.dhall
+++ b/src/k8s/components/minio/configuration/environment/environment.dhall
@@ -6,17 +6,17 @@ let Simple/Minio/Environment =
 
 let environment =
       { Type =
-          { MINIO_ACCESS_KEY : Kubernetes/EnvVar.Type
-          , MINIO_SECRET_KEY : Kubernetes/EnvVar.Type
+          { MINIO_ROOT_USER : Kubernetes/EnvVar.Type
+          , MINIO_ROOT_PASSWORD : Kubernetes/EnvVar.Type
           }
       , default =
-        { MINIO_ACCESS_KEY = Kubernetes/EnvVar::{
-          , name = Simple/Minio/Environment.MINIO_ACCESS_KEY.name
-          , value = Some "${Simple/Minio/Environment.MINIO_ACCESS_KEY.value}"
+        { MINIO_ROOT_USER = Kubernetes/EnvVar::{
+          , name = Simple/Minio/Environment.MINIO_ROOT_USER.name
+          , value = Some "${Simple/Minio/Environment.MINIO_ROOT_USER.value}"
           }
-        , MINIO_SECRET_KEY = Kubernetes/EnvVar::{
-          , name = Simple/Minio/Environment.MINIO_SECRET_KEY.name
-          , value = Some "${Simple/Minio/Environment.MINIO_SECRET_KEY.value}"
+        , MINIO_ROOT_PASSWORD = Kubernetes/EnvVar::{
+          , name = Simple/Minio/Environment.MINIO_ROOT_PASSWORD.name
+          , value = Some "${Simple/Minio/Environment.MINIO_ROOT_PASSWORD.value}"
           }
         }
       }

--- a/src/k8s/components/minio/configuration/toInternal.dhall
+++ b/src/k8s/components/minio/configuration/toInternal.dhall
@@ -118,7 +118,7 @@ let fixtures =
              . Containers
              . minio
              . environment
-             . MINIO_ACCESS_KEY
+             . MINIO_ROOT_USER
              . value
              = Some
             "FOO"
@@ -127,7 +127,7 @@ let fixtures =
              . Containers
              . minio
              . environment
-             . MINIO_SECRET_KEY
+             . MINIO_ROOT_PASSWORD
              . value
              = Some
             "BAR"
@@ -226,11 +226,11 @@ let Test/Deployment/Containers/minio/environment =
           :   outputs.userSettings.Deployment.containers.minio.envVars
             ≡ Some
                 [ Kubernetes/EnvVar::{
-                  , name = "MINIO_ACCESS_KEY"
+                  , name = "MINIO_ROOT_USER"
                   , value = Some "FOO"
                   }
                 , Kubernetes/EnvVar::{
-                  , name = "MINIO_SECRET_KEY"
+                  , name = "MINIO_ROOT_PASSWORD"
                   , value = Some "BAR"
                   }
                 ]

--- a/src/simple/minio/package.dhall
+++ b/src/simple/minio/package.dhall
@@ -22,10 +22,10 @@ let healthCheck =
 let volumes = { minio-data = "/data" }
 
 let environment =
-      { MINIO_ACCESS_KEY =
-        { name = "MINIO_ACCESS_KEY", value = "AKIAIOSFODNN7EXAMPLE" }
-      , MINIO_SECRET_KEY =
-        { name = "MINIO_SECRET_KEY"
+      { MINIO_ROOT_USER =
+        { name = "MINIO_ROOT_USER", value = "AKIAIOSFODNN7EXAMPLE" }
+      , MINIO_ROOT_PASSWORD =
+        { name = "MINIO_ROOT_PASSWORD"
         , value = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
         }
       }


### PR DESCRIPTION
Update minio environment variables to new convention. 
Addresses https://github.com/sourcegraph/sourcegraph/issues/26529.

[_Created by Sourcegraph batch change `kevin.wojkovich/minio-envvar-update`._](https://k8s.sgdev.org/users/kevin.wojkovich/batch-changes/minio-envvar-update)